### PR TITLE
fix: 补充 workflow 矩阵中缺失的内核版本

### DIFF
--- a/.github/workflows/kernel-a14-6-1.yml
+++ b/.github/workflows/kernel-a14-6-1.yml
@@ -150,6 +150,10 @@ jobs:
             os_patch_level: "2025-09"
           - sub_level: "157"
             os_patch_level: "2025-12"
+          - sub_level: "162"
+            os_patch_level: "2026-03"
+          - sub_level: "172"
+            os_patch_level: "2026-06"
           - sub_level: "X"
             os_patch_level: "lts"
     uses: ./.github/workflows/build.yml

--- a/.github/workflows/kernel-a15-6-6.yml
+++ b/.github/workflows/kernel-a15-6-6.yml
@@ -142,6 +142,8 @@ jobs:
             os_patch_level: "2025-10"
           - sub_level: "118"
             os_patch_level: "2026-01"
+          - sub_level: "127"
+            os_patch_level: "2026-04"
           - sub_level: "X"
             os_patch_level: "lts"
     uses: ./.github/workflows/build.yml

--- a/.github/workflows/kernel-a16-6-12.yml
+++ b/.github/workflows/kernel-a16-6-12.yml
@@ -122,6 +122,10 @@ jobs:
             os_patch_level: "2025-09"
           - sub_level: "58"
             os_patch_level: "2025-12"
+          - sub_level: "69"
+            os_patch_level: "2026-03"
+          - sub_level: "81"
+            os_patch_level: "2026-06"
           - sub_level: "X"
             os_patch_level: "lts"
     uses: ./.github/workflows/build.yml


### PR DESCRIPTION
`data/` 下的 JSON 已通过 `update_data.py` 更新到最新，
但对应 workflow 的 build matrix 未同步新增的版本：

| 工作流 | 新增版本 |
|---|---|
| `kernel-a14-6-1.yml` | 6.1.162 (2026-03), 6.1.172 (2026-06) |
| `kernel-a15-6-6.yml` | 6.6.127 (2026-04) |
| `kernel-a16-6-12.yml` | 6.12.69 (2026-03), 6.12.81 (2026-06) |

> kernel-a12-5-10 的 5.10.246 和 kernel-a13-5-15 的 5.15.194 已在矩阵中。